### PR TITLE
Address to github organization members has changed to /orgs/{orgName}/people

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
           <h1>SoCo</h1>
           <p>Controlling your Sonos speakers from Python and the commandline</p>
           <hr>
-          <span class="credits left">Project maintained by the <a href="https://github.com/orgs/SoCo/members">SoCo-Team</a></span>
+          <span class="credits left">Project maintained by the <a href="https://github.com/orgs/SoCo/people">SoCo-Team</a></span>
           <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></span>
         </div>
 


### PR DESCRIPTION
I was looking for something else on http://python-soco.com/ when I clicked this link and realized it was wrong.
